### PR TITLE
Improve getFullDn() to retrieve RDN

### DIFF
--- a/LibreNMS/Authentication/LdapAuthorizer.php
+++ b/LibreNMS/Authentication/LdapAuthorizer.php
@@ -286,7 +286,12 @@ class LdapAuthorizer extends AuthorizerBase
      */
     protected function getFullDn($username)
     {
-        return Config::get('auth_ldap_prefix', '') . $username . Config::get('auth_ldap_suffix', '');
+        $connection = $this->getLdapConnection();
+        $filter = '(' . Config::get('auth_ldap_prefix') . $this->userloginname . ')';
+        $base_dn = preg_replace('/,ou=[^,]+,/', '', Config::get('auth_ldap_suffix'));
+        $search = ldap_search($connection, $base_dn, $filter);
+        $firstuser = ldap_first_entry($connection, $search);
+        return ldap_get_dn($connection, $firstuser);
     }
 
     /**

--- a/LibreNMS/Authentication/LdapAuthorizer.php
+++ b/LibreNMS/Authentication/LdapAuthorizer.php
@@ -291,6 +291,7 @@ class LdapAuthorizer extends AuthorizerBase
         $base_dn = preg_replace('/,ou=[^,]+,/', '', Config::get('auth_ldap_suffix'));
         $search = ldap_search($connection, $base_dn, $filter);
         $firstuser = ldap_first_entry($connection, $search);
+
         return ldap_get_dn($connection, $firstuser);
     }
 


### PR DESCRIPTION
The previous instance of getFullDn() naively composed the RDN that is then used in the user bind attempt by prefixing and suffixing the attributes defined in config.php.

It may be desirable to allow login with an arbitrary attribute (i.e. mail address), or, as it is the case for me, when the LDAP server does not store the username as the primary key for the entity, and therefore a typical login based on uid would fail.

I believe this change should not impact existing installations as it would still compose the same DN. My testing on this has however been limited. 

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [x] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
